### PR TITLE
Use non-ambiguous last updated format

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -60,7 +60,7 @@ template = Template("""
 {% endfor %}
 </tbody>
 </table>
-<p>Last updated at {{ generation_time.strftime('%x %X %Z') }}.</p>
+<p>Last updated at {{ generation_time.strftime('%A, %d %B %Y, %X %Z') }}.</p>
 </body>
 </html>
 """)

--- a/index.html
+++ b/index.html
@@ -110,6 +110,6 @@
 
 </tbody>
 </table>
-<p>Last updated at 11/19/24 11:17:03 UTC.</p>
+<p>Last updated at Tuesday, 19 November 2024, 11:28:25 UTC.</p>
 </body>
 </html>


### PR DESCRIPTION
It's not always obvious if US or international date format is used for dates like 12/12/24.

Let's use an unambiguous format instead.
