### PR TITLE
Upload build files as artifact

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,6 +13,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/setup-python@main
+        with:
+          python-version: "3.x"
       - uses: astral-sh/setup-uv@main
       - uses: actions/checkout@main
       - run: uv run generate.py  # generates "index.html"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -31,3 +31,7 @@ jobs:
           curl -Lo index.html-public https://github.com/m-aciek/pydocs-translation-dashboard/raw/refs/heads/gh-pages/index.html
           diff --color=always -u index.html-public index.html || :
           cat index.html
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,11 +12,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/setup-python@main
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@main
-      - uses: actions/checkout@main
+      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v4
       - run: uv run generate.py  # generates "index.html"
       - run: mkdir -p build && cp index.html style.css build
       - name: Deploy 🚀


### PR DESCRIPTION
So they can be downloaded from the build summary to see what they look like.

Also pin actions to avoid surprising breaking changes and add python-version to fix warning.
