### PR TITLE
Add readthedocs preview

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -1,0 +1,24 @@
+name: Read the Docs PR preview
+# Automatically edits a pull request's descriptions with a link
+# to the documentation's preview on Read the Docs.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "pydocs-translation-dashboard"
+          single-version: "true"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Project page: https://app.readthedocs.org/projects/pydocs-translation-dashboard/
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3"
+  commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv run generate.py
+    - mkdir -p _readthedocs/html
+    - mv index.html style.css _readthedocs/html


### PR DESCRIPTION
When on pull request, this builds the webpage in readthedocs and adds preview link.

This was suggested by @hugovk in https://github.com/m-aciek/pydocs-translation-dashboard/pull/11#issuecomment-2502998463 and inspired in CPython's solution.

[Example of build](https://app.readthedocs.org/projects/pydocs-translation-dashboard/builds/26426095/) with everything properly set.