### PR TITLE
Fetch bugfix and security branches from devguide

### DIFF
--- a/completion.py
+++ b/completion.py
@@ -3,11 +3,25 @@ import shutil
 
 import git
 from potodo import potodo
+import requests
+
+
+def branches_from_devguide() -> list[str]:
+    r = requests.get(
+        "https://raw.githubusercontent.com/"
+        "python/devguide/main/include/release-cycle.json",
+        timeout=10,
+    )
+    data = r.json()
+    return [
+        branch for branch in data if data[branch]["status"] in ("bugfix", "security")
+    ]
 
 
 def get_completion_and_branch(tmpdir: str, language: str) -> tuple[float, str]:
     clone_path = pathlib.Path(tmpdir, language)
-    for branch in ('3.13', '3.12', '3.11', '3.10', '3.9'):
+
+    for branch in branches_from_devguide():
         try:
             git.Repo.clone_from(f'https://github.com/python/python-docs-{language}.git', clone_path, depth=1, branch=branch)
         except git.GitCommandError:


### PR DESCRIPTION
Instead of hardcoding 3.9-3.13, get the list of supported branches from the official list in the devguide:

https://github.com/python/devguide/blob/main/include/release-cycle.json

This file is the source for the diagram and tables at:

https://devguide.python.org/versions/

We do something similar in the docsbuild-scripts repo:

https://github.com/python/docsbuild-scripts/blob/b2b548353b50a3316ba098b89382fe6b8f8474a9/build_docs.py#L1129-L1138

<!-- readthedocs-preview pydocs-translation-dashboard start -->
----
📚 Documentation preview 📚: https://pydocs-translation-dashboard--16.org.readthedocs.build/

<!-- readthedocs-preview pydocs-translation-dashboard end -->