### PR TITLE
Indicate languages in the docs.python.org switcher

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -64,6 +64,7 @@ template = Template(
 <thead>
 <tr>
   <th>language</th>
+  <th>build</th>
   <th><a href="https://plausible.io/data-policy#how-we-count-unique-users-without-cookies">visitors<a/></th>
   <th>translators</th>
   <th>completion</th>
@@ -75,9 +76,15 @@ template = Template(
   {% if repo %}
   <td data-label="language">
     <a href="https://github.com/{{ repo }}" target="_blank">
-      {{ language -}}
+      {{ language }}
     </a>
-    {{- "*" if in_switcher else "" }}
+  </td>  
+  <td data-label="build">
+    {% if in_switcher %}
+      <a href="https://docs.python.org/{{ language }}/">in switcher</a>
+    {% else %}
+      ✗
+    {% endif %}
   </td>
   <td data-label="visitors">
     <a href="https://plausible.io/docs.python.org?filters=((contains,page,(/{{ language }}/)))" target="_blank">
@@ -97,7 +104,6 @@ template = Template(
 {% endfor %}
 </tbody>
 </table>
-<p>* Language is in the <a href="https://docs.python.org">docs.python.org</a> switcher.</p>
 <p>Last updated at {{ generation_time.strftime('%A, %d %B %Y, %X %Z') }}.</p>
 </body>
 </html>

--- a/generate.py
+++ b/generate.py
@@ -32,7 +32,7 @@ with TemporaryDirectory() as clones_dir:
     )
     subprocess.run(['make', '-C', Path(clones_dir, 'cpython/Doc'), 'venv'], check=True)
     subprocess.run(['make', '-C', Path(clones_dir, 'cpython/Doc'), 'gettext'], check=True)
-    switcher_languages = switcher.get_languages()
+    switcher_languages = list(switcher.get_languages())
     for language, repo in repositories.get_languages_and_repos(devguide_dir):
         if repo:
             completion_number, translators_number = get_completion(clones_dir, repo)
@@ -46,7 +46,7 @@ with TemporaryDirectory() as clones_dir:
                 completion_number,
                 translators_number,
                 visitors_number,
-                switcher_languages[language],
+                language in switcher_languages,
             )
         )
         print(completion_progress[-1])

--- a/style.css
+++ b/style.css
@@ -25,10 +25,10 @@ th {
   min-width: 50px;
   box-sizing: border-box;
 }
-td:nth-child(2) {
+td[data-label="visitors"] {
   text-align: right;
 }
-td:last-child {
+td[data-label="completion"] {
   width: 100%;
 }
 @media screen and (max-width: 600px) {
@@ -56,7 +56,7 @@ td:last-child {
     left: 10px;
     position: absolute;
   }
-  td:last-child {
+  td[data-label="completion"] {
     width: inherit;
   }
   .progress-bar {

--- a/switcher.py
+++ b/switcher.py
@@ -11,20 +11,18 @@ from collections import defaultdict
 import requests
 
 
-def get_languages() -> defaultdict[str, bool]:
-    # Languages missing from config.toml are not in production
-    in_prod = defaultdict(lambda: False)
+def get_languages() -> Generator[str, None, None]:
     data = requests.get(
         "https://raw.githubusercontent.com/"
         "python/docsbuild-scripts/refs/heads/main/config.toml",
         timeout=10,
     ).text
-    languages = tomllib.loads(data)["languages"]
+    config = tomllib.loads(data)
+    languages = config["languages"]
+    defaults = config["defaults"]
     for code, language in languages.items():
-        code = code.lower().replace("_", "-")
-        # Languages in config.toml default to being in production
-        in_prod[code] = language.get("in_prod", True)
-    return in_prod
+        if language.get("in_prod", defaults["in_prod"]):
+            yield code.lower().replace("_", "-")
 
 
 def main() -> None:

--- a/switcher.py
+++ b/switcher.py
@@ -7,6 +7,7 @@ whether it is in the language switcher.
 
 import tomllib
 from collections import defaultdict
+from typing import Generator
 
 import requests
 
@@ -26,10 +27,10 @@ def get_languages() -> Generator[str, None, None]:
 
 
 def main() -> None:
-    languages = get_languages()
+    languages = list(get_languages())
     print(languages)
     for code in ("en", "pl", "ar", "zh-cn"):
-        print(f"{code}: {languages[code]}")
+        print(f"{code}: {code in languages}")
 
 
 if __name__ == "__main__":

--- a/switcher.py
+++ b/switcher.py
@@ -1,0 +1,38 @@
+"""
+Fetch languages in the https://docs.python.org language switcher.
+
+Return a defaultdict mapping language codes to a Boolean indicating
+whether it is in the language switcher.
+"""
+
+import tomllib
+from collections import defaultdict
+
+import requests
+
+
+def get_languages() -> defaultdict[str, bool]:
+    # Languages missing from config.toml are not in production
+    in_prod = defaultdict(lambda: False)
+    data = requests.get(
+        "https://raw.githubusercontent.com/"
+        "python/docsbuild-scripts/refs/heads/main/config.toml",
+        timeout=10,
+    ).text
+    languages = tomllib.loads(data)["languages"]
+    for code, language in languages.items():
+        code = code.lower().replace("_", "-")
+        # Languages in config.toml default to being in production
+        in_prod[code] = language.get("in_prod", True)
+    return in_prod
+
+
+def main() -> None:
+    languages = get_languages()
+    print(languages)
+    for code in ("en", "pl", "ar", "zh-cn"):
+        print(f"{code}: {languages[code]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Mark the languages that are in the language switcher with an asterisk.

We could mark them some other way too, if you've got a better idea?

<!-- readthedocs-preview pydocs-translation-dashboard start -->
----
📚 Documentation preview 📚: https://pydocs-translation-dashboard--24.org.readthedocs.build/

<!-- readthedocs-preview pydocs-translation-dashboard end -->